### PR TITLE
Arreglar y homogeneizar parámetro disqus_url

### DIFF
--- a/content/autores/javi.md
+++ b/content/autores/javi.md
@@ -9,7 +9,7 @@ tags:
 
 disqus_identifier: quien-es-javi
 disqus_title: ¿Quién es Javi?
-disqus_url: //programar.cloud/javi
+disqus_url: "//programar.cloud/autores/quien-es-javi"
 --- 
 
 

--- a/content/noticias/20161113-salgo-en-el-podcast-wedevelopers.md
+++ b/content/noticias/20161113-salgo-en-el-podcast-wedevelopers.md
@@ -23,7 +23,7 @@ explicit : "no"
 
 disqus_identifier: podcast-wedevelopers-docker
 disqus_title: WeDevelopers & Docker
-disqus_url: "https://programar.cloud/podcast-wedevelopers-docker"
+disqus_url: "//programar.cloud/noticias/podcast-wedevelopers-docker"
 --- 
 
 {{% img src="/media/we-developers-docker.png" alt="we.developers podcast" %}}

--- a/content/noticias/20161118-feed-compatible-con-podcatcher.md
+++ b/content/noticias/20161118-feed-compatible-con-podcatcher.md
@@ -14,7 +14,7 @@ niveles:
 
 disqus_identifier: feed-rss-compatible-podcatchers
 disqus_title: "Feed RSS compatible con podcatchers"
-disqus_url: "https://programar.cloud/post/feed-rss-compatible-podcatchers"
+disqus_url: "//programar.cloud/noticias/feed-rss-compatible-podcatcher"
 --- 
 
 {{% img src="/media/headphones.jpg" alt="auriculares" %}}

--- a/content/post/0000-aprende-a-crear-aplicaciones-cloud.md
+++ b/content/post/0000-aprende-a-crear-aplicaciones-cloud.md
@@ -22,7 +22,7 @@ explicit : "no"
 
 disqus_identifier: aprende-a-crear-aplicaciones-cloud
 disqus_title: Aprende a crear apliaciones cloud
-disqus_url: //programar.cloud/post/aprende-a-crear-aplicaciones-cloud
+disqus_url: "//programar.cloud/post/aprende-a-crear-aplicaciones-cloud"
 ---
 
 {{% img src="/media/dontpanic.jpg" alt="Don't panic" %}}

--- a/content/post/1000-el-cloud-es-donde-se-ejecutan-las-aplicaciones.md
+++ b/content/post/1000-el-cloud-es-donde-se-ejecutan-las-aplicaciones.md
@@ -23,7 +23,7 @@ explicit : "no"
 
 disqus_identifier: el-cloud-es-donde-se-ejecutan-las-aplicaciones
 disqus_title: El Cloud es donde se ejecutan las aplicaciones
-disqus_url: //programar.cloud/post/el-cloud-es-donde-se-ejecutan-las-aplicaciones
+disqus_url: "//programar.cloud/post/cloud-es-donde-se-ejecutan-las-aplicaciones"
 ---
  
 

--- a/content/post/1006-programacion-distribuida-con-rmi.md
+++ b/content/post/1006-programacion-distribuida-con-rmi.md
@@ -22,7 +22,7 @@ explicit : "no"
 
 disqus_identifier: programacion-distribuida-con-rmi
 disqus_title: Programación distribuída con RMI
-disqus_url: "https://programar.cloud/post/programacion-distribuida-con-rmi"
+disqus_url: "//programar.cloud/post/programacion-distribuida-con-rmi"
 ---      
 
 En este vídeo te cuento cómo puedes crear aplicaciones java distribuídas usando Remote Method Invocation para ello. Aunque esta tecnología ya no es popular creo es interesante que tengas al menos nociones sobre este tipo de arquitectura para poder comprarla con el modelo actual de microservicios conectados por APIs REST. ¡Disfruta!

--- a/content/post/1007-taxonomia-cloud-iaas-paas-saas.md
+++ b/content/post/1007-taxonomia-cloud-iaas-paas-saas.md
@@ -24,7 +24,7 @@ explicit : "no"
 
 disqus_identifier: taxonomia-cloud-iaas-paas-saas
 disqus_title: El nacimiento de los web services
-disqus_url: "https://programar.cloud/post/taxonomia-cloud-iaas-paas-saas"
+disqus_url: "//programar.cloud/post/taxonomia-cloud-iaas-paas-saas"
 ---   
 
 ¡Más conceptos básicos importantes! Te doy una visión actualizada de lo que es Infrastructure as a Service, Plataform as a Service y Software as a Service. Hablo de VMWare, Digital Ocean, AWS, Azure, Salesforce y otros. Si no tienes claro algo ¡comenta!

--- a/content/post/1010-desde-las-aplicaciones-monoliticas-hasta-los-microservicios.md
+++ b/content/post/1010-desde-las-aplicaciones-monoliticas-hasta-los-microservicios.md
@@ -24,7 +24,7 @@ explicit : "no"
 
 disqus_identifier: desde-las-aplicaciones-monoliticas-hasta-los-microservicios
 disqus_title: Desde monolíticas hasta microservicios
-disqus_url: https://programar.cloud/post/desde-monoliticas-hasta-microservicios
+disqus_url: "//programar.cloud/post/desde-monoliticas-hasta-microservicios"
 ---
 
 {{% img src="/media/almacen.jpg" alt="almacén lleno de stock" %}}

--- a/content/post/1011-la-evolucion-del-coste-del-hardware.md
+++ b/content/post/1011-la-evolucion-del-coste-del-hardware.md
@@ -23,7 +23,7 @@ explicit : "no"
 
 disqus_identifier: la-evolucion-del-coste-del-hardware
 disqus_title: "¿Cuánto pagarías por este servidor?"
-disqus_url: "https://programar.cloud/post/la-evolucion-del-coste-del-hardware"
+disqus_url: "//programar.cloud/post/la-evolucion-del-coste-del-hardware"
 ---      
 
 Un *más o menos rápido* viaje en el que comparamos cuánto te costaría crear una pequeña flota de servidores en los años 90 con lo que te supone lanzarla ahora en el cloud de AWS. Con su poquito de nostalgia extra si sois de mi generación ;-)

--- a/content/post/1012-magia-desde-la-linea-de-comandos.md
+++ b/content/post/1012-magia-desde-la-linea-de-comandos.md
@@ -23,7 +23,7 @@ explicit : "no"
 
 disqus_identifier: magia-desde-la-linea-de-comandos
 disqus_title: Magia desde la línea de comandos
-disqus_url: "https://programar.cloud/post/magia-desde-la-linea-de-comandos"
+disqus_url: "//programar.cloud/post/magia-desde-la-linea-de-comandos"
 ---      
 
 Te cuento muy rápidamente cómo puedes encadenar una serie de pequeños programitas de línea de comandos para llevar a cabo un trabajo interesante y relativamente complejo. Y lo dicho, tenemos que volver a las raíces: pequeños componentes independientes que se encadenen entre ellos fácilmente.

--- a/content/post/1020-que-son-los-microservicios.md
+++ b/content/post/1020-que-son-los-microservicios.md
@@ -22,7 +22,7 @@ explicit : "no"
 
 disqus_identifier: que-son-los-microservicios
 disqus_title: ¿Qué son los microservicios
-disqus_url: "https://programar.cloud/post/que-son-los-microservicios"
+disqus_url: "//programar.cloud/post/que-son-los-microservicios"
 ---      
 
 {{% img src="/media/micro-machine.jpg" alt="Micromachines" class="framed" %}}

--- a/content/post/1030-microservicios-en-el-mundo-real.md
+++ b/content/post/1030-microservicios-en-el-mundo-real.md
@@ -22,7 +22,7 @@ explicit : "no"
 
 disqus_identifier: microservicios-en-el-mundo-real
 disqus_title: Microservicios en el mundo real
-disqus_url: "//programar.cloud/posts/microservicios-en-el-mundo-real"
+disqus_url: "//programar.cloud/post/microservicios-en-el-mundo-real"
 ---
 
 {{% img src="/media/amazon-homepage.jpg" alt="Amazon front page" class="framed" %}}

--- a/content/post/1030-microservicios-en-el-mundo-real.md
+++ b/content/post/1030-microservicios-en-el-mundo-real.md
@@ -22,7 +22,7 @@ explicit : "no"
 
 disqus_identifier: microservicios-en-el-mundo-real
 disqus_title: Microservicios en el mundo real
-disqus_url: https://programar.cloud/posts/microservicios-en-el-mundo-real
+disqus_url: "//programar.cloud/posts/microservicios-en-el-mundo-real"
 ---
 
 {{% img src="/media/amazon-homepage.jpg" alt="Amazon front page" class="framed" %}}

--- a/content/post/1040-devops-en-serio.md
+++ b/content/post/1040-devops-en-serio.md
@@ -14,7 +14,7 @@ niveles:
 
 disqus_identifier: devops-en-serio
 disqus_title: Microservicios en el mundo real
-disqus_url: //programar.cloud/post/devops-en-serio
+disqus_url: "//programar.cloud/post/devops-en-serio"
 ---
 
 {{% img src="/media/velocidad.jpg" alt="Velocidad" %}}

--- a/content/post/1050-microservicios-rest-en-10-minutos.md
+++ b/content/post/1050-microservicios-rest-en-10-minutos.md
@@ -18,7 +18,7 @@ niveles:
 
 disqus_identifier: microservicios-rest-en-10-minutos-con-springboot
 disqus_title: Microservicios REST en 10 minutos con SpringBoot
-disqus_url: //programar.cloud/post/microservicios-rest-en-10-minutos-con-springboot
+disqus_url: "//programar.cloud/post/microservicios-rest-en-10-minutos-con-springboot"
 ---
 
 {{% img src="/media/cloud-money.jpg" alt="Dinero y poder en el cloud" %}}

--- a/content/post/1060-vamos-a-disenar-un-proyecto.md
+++ b/content/post/1060-vamos-a-disenar-un-proyecto.md
@@ -18,7 +18,7 @@ niveles:
 
 disqus_identifier: vamos-a-diseñar-un-proyecto-con-microservicios
 disqus_title: Vamos a diseñar un proyecto con microservicios
-disqus_url: //programar.cloud/post/vamos-a-diseñar-un-proyecto-con-microservicios
+disqus_url: "//programar.cloud/post/vamos-a-diseñar-un-proyecto-con-microservicios"
 ---
 
 {{% img src="/media/cloud-money.jpg" alt="Dinero y poder en el cloud" %}}


### PR DESCRIPTION
Buenas.

Creo que había que hacer un poco de limpieza en ese parámetro. Algunos estaban mal y el formato no era homogéneo.

El disqus_identifier no lo he tocado en ningún caso; aunque no se corresponda con el slug, de esa forma no pierdes comentarios ya realizados. Si lo quieres cambiar, tienes que migrarlo usando el propio panel de Disqus.

Abrazos.